### PR TITLE
Use selector that doesn't change; wait for navigation

### DIFF
--- a/actions/login.js
+++ b/actions/login.js
@@ -9,14 +9,17 @@ const data = {
 
 async function doLogin (page) {
   console.log('Action'.bgWhite.black, 'doLogin');
-  
+
   await page.screenshot({path: './prints/01-before-login.png'});
   await page.click('.abaLogin li:nth-child(2) a');
   await page.screenshot({path: './prints/02-before-login.png'});
   await page.type('input[name="codigoEmpregador"]', data.codigoEmpregador);
   await page.type('input[name="pin"]', data.pin);
   await page.screenshot({path: './prints/03-before-login.png'});
-  await page.click('#idc');
+  await Promise.all([
+    page.click('form div:nth-child(6) input'),
+    page.waitForNavigation()
+  ]);
   await page.screenshot({path: './prints/04-after-login.png'});
 }
 

--- a/actions/login.js
+++ b/actions/login.js
@@ -17,7 +17,7 @@ async function doLogin (page) {
   await page.type('input[name="pin"]', data.pin);
   await page.screenshot({path: './prints/03-before-login.png'});
   await Promise.all([
-    page.click('form div:nth-child(6) input'),
+    page.click('.btnLogin'),
     page.waitForNavigation()
   ]);
   await page.screenshot({path: './prints/04-after-login.png'});


### PR DESCRIPTION
The button ID changes as the page is reloaded. To reproduce, just open Tangerino login page and repeatedly examine the ID after pressing f5.

Adding a `waitForNavigation` solved the following crash:

`Error: Execution context was destroyed, most likely because of a navigation.`

